### PR TITLE
Orbit Activity Object Enhancements for Twitch Interactions

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -48,6 +48,7 @@ export abstract class Handlers {
       `Used command ${command} on Twitch`,
       this.weights.weightCommand?.toFixed(2),
       'twitch:command',
+      ['channel:twitch'],
       `twitch-command-${user}-${command}-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
       date.toISOString()
     );
@@ -66,10 +67,11 @@ export abstract class Handlers {
     const date = new Date();
 
     const activity = new Activity(
-      'Chat on Twitch',
-      'Chatted on Twitch',
+      'Participated in Twitch Chat',
+      message,
       this.weights.weightChat?.toFixed(2),
       'twitch:chat',
+      ['channel:twitch'],
       `twitch-chat-${user}-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
       date.toISOString()
     );
@@ -90,6 +92,7 @@ export abstract class Handlers {
       `Cheered ${bits} on Twitch`,
       this.weights.weightCheer?.toFixed(2),
       'twitch:cheer',
+      ['channel:twitch'],
       `twitch-cheer-${user}-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
       date.toISOString()
     );
@@ -110,6 +113,7 @@ export abstract class Handlers {
       `Raided with ${viewers} viewers on Twitch`,
       this.weights.weightRaid?.toFixed(2),
       'twitch:raid',
+      ['channel:twitch'],
       `twitch-raid-${user}-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
       date.toISOString()
     );
@@ -130,6 +134,7 @@ export abstract class Handlers {
       `Resub for ${cumulativeMonths} months on Twitch`,
       this.weights.weightSub?.toFixed(2),
       'twitch:sub',
+      ['channel:twitch'],
       `twitch-sub-${user}-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
       date.toISOString()
     );
@@ -150,6 +155,7 @@ export abstract class Handlers {
       `Sub on Twitch`,
       this.weights.weightSub?.toFixed(2),
       'twitch:sub',
+      ['channel:twitch'],
       `twitch-sub-${user}-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
       date.toISOString()
     );
@@ -170,6 +176,7 @@ export abstract class Handlers {
       `Sub on Twitch`,
       this.weights.weightSub?.toFixed(2),
       'twitch:sub',
+      ['channel:twitch'],
       `twitch-sub-${recipientUser}-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
       date.toISOString()
     );
@@ -181,6 +188,7 @@ export abstract class Handlers {
       `Gifted sub to ${recipientUser} on Twitch`,
       this.weights.weightGiftSub?.toFixed(2),
       'twitch:sub:gift',
+      ['channel:twitch'],
       `twitch-sub-gift-${recipientUser}-${gifterUser}-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
       date.toISOString()
     );

--- a/src/orbit.ts
+++ b/src/orbit.ts
@@ -31,6 +31,7 @@ export class Activity {
     public description?: string,
     public weight?: string,
     public activity_type?: string,
+    public tags?: Array<string>,
     public key?: string,
     public occurred_at?: string
   ) {}


### PR DESCRIPTION
In this pull request I add a couple enhancements to the construction of the Orbit activity object, which reflects in the Orbit app when viewing activities.

Namely:

* Adding a tag of `channel:twitch` will cause a Twitch platform to manifest in the Channel dropdowns in the UI as seen in the screenshot here:
  * ![Screen Shot 2021-07-02 at 9 56 36](https://user-images.githubusercontent.com/13892277/124233726-cc1d3c00-db1b-11eb-969a-e20e858c4387.png)
* Secondly, I've changed the description of each chat message to be the message, which will allow for more context when viewing member activities as time progresses. It's more descriptive than a generic left a message description without the details.